### PR TITLE
Detect and ignore binary diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ This module will go through the entire commit history of each branch, and check 
 
 ## Wishlist
 
-- A way to detect and not scan binary diffs
+- ~~A way to detect and not scan binary diffs~~
 - Don't rescan diffs if already looked at in another branch

--- a/truffleHog.py
+++ b/truffleHog.py
@@ -72,7 +72,11 @@ def find_strings(git_url):
                 diff = prev_commit.diff(curr_commit, create_patch=True)
                 for blob in diff:
                     #print i.a_blob.data_stream.read()
-                    printableDiff = blob.diff.decode() 
+                    printableDiff = blob.diff.decode()
+                    if printableDiff.startswith("Binary files"):
+                        # print("[DEBUG] DETECTED BINARY FILE DIFF")
+                        continue
+                    # print("[DEBUG] Normal diff")
                     foundSomething = False
                     lines = blob.diff.decode().split("\n")
                     for line in lines:


### PR DESCRIPTION
Implements the first item on the wishlist:

> A way to detect and not scan binary diffs


From my experiments, a binary diff always starts with the string "Binary files". So checking if `printableDiff` starts with that string will let us detect and ignore a binary diff. 