### PR TITLE
ignores duplicate diffs caused by branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ This module will go through the entire commit history of each branch, and check 
 ## Wishlist
 
 - A way to detect and not scan binary diffs
-- Don't rescan diffs if already looked at in another branch
+- ~~Don't rescan diffs if already looked at in another branch~~

--- a/truffleHog.py
+++ b/truffleHog.py
@@ -57,6 +57,7 @@ def find_strings(git_url):
     repo = Repo(project_path)
 
 
+    already_searched = set()
     for remote_branch in repo.remotes.origin.fetch():
         branch_name = str(remote_branch).split('/')[1]
         try:
@@ -69,6 +70,13 @@ def find_strings(git_url):
             if not prev_commit:
                 pass
             else:
+                #avoid searching the same diffs
+                hashes = str(prev_commit) + str(curr_commit)
+                if hashes in already_searched:
+                    prev_commit = curr_commit
+                    continue
+                already_searched.add(hashes)
+
                 diff = prev_commit.diff(curr_commit, create_patch=True)
                 for blob in diff:
                     #print i.a_blob.data_stream.read()


### PR DESCRIPTION
Implements the second item in the wishlist:
> - Don't rescan diffs if already looked at in another branch