### PR TITLE
Gracefully Handle Failure to decode non 'utf-8' codec

### DIFF
--- a/truffleHog.py
+++ b/truffleHog.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import shutil
 import sys
 import math
@@ -8,10 +10,6 @@ import tempfile
 import os
 import stat
 from git import Repo
-
-if sys.version_info[0] == 2:
-    reload(sys)  
-    sys.setdefaultencoding('utf8')
 
 BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
 HEX_CHARS = "1234567890abcdefABCDEF"
@@ -68,8 +66,8 @@ def find_strings(git_url):
 
     repo = Repo(project_path)
 
-
     already_searched = set()
+
     for remote_branch in repo.remotes.origin.fetch():
         branch_name = str(remote_branch).split('/')[1]
         try:
@@ -92,7 +90,7 @@ def find_strings(git_url):
                 diff = prev_commit.diff(curr_commit, create_patch=True)
                 for blob in diff:
                     #print i.a_blob.data_stream.read()
-                    printableDiff = blob.diff.decode()
+                    printableDiff = blob.diff.decode('utf-8', errors='replace')
                     if printableDiff.startswith("Binary files"):
                         continue
                     foundSomething = False


### PR DESCRIPTION
Fixes  #7 and #27 

Leverage replacement character when decode of unrecognized character encoding encountered and streamlined Python 2+ header encoding.

This is most likely occurring when git commit pulled down is NOT a UTF-8 encoded content-type response.  For example it might be legacy HTML encoded via  iso-8859-1.  Rather than try to determine string's encoding type (incredibly difficult) simply handle decode error gracefully.

Simple example
`'\xa9'.decode('utf-8', errors='replace')
u'\ufffd'`


