### PR TITLE
Add a minimal Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:2-alpine
+RUN apk add --no-cache git && pip install trufflehog
+WORKDIR /proj
+ENTRYPOINT [ "trufflehog" ]
+CMD [ "-h" ]
+# CMD [ "file:///proj" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,3 @@ RUN apk add --no-cache git && pip install trufflehog
 WORKDIR /proj
 ENTRYPOINT [ "trufflehog" ]
 CMD [ "-h" ]
-# CMD [ "file:///proj" ]


### PR DESCRIPTION
I'm aware of the other PRs regarding a Dockerfile - this one is kept minimal and relies only on the PyPI module.

Usage is like follows for a lokal repository:

```
docker run --rm -it -v `pwd`:/proj <org>/trufflehog file:///proj
```

A more complex example looks like this:

```
docker run --rm -it -v `pwd`:/proj -v `pwd`/rules.json:/rules.json <org>/trufflehog --rules /rules.json --regex --entropy=False file:///proj
```
