### PR TITLE
Supports slashes into branch names

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -217,7 +217,7 @@ def find_strings(git_url, since_commit=None, max_depth=None, printJson=False, do
 
     for remote_branch in repo.remotes.origin.fetch():
         since_commit_reached = False
-        branch_name = remote_branch.name.split('/')[1]
+        _, _, branch_name = remote_branch.name.partition('/')
         try:
             repo.git.checkout(remote_branch, b=branch_name)
         except:


### PR DESCRIPTION
Hello,

I was trying `truffleHog` and was browsing results when I noticed an incomplete branch name.
For example, a branch named `feature/do_stuff` shows as `feature` - the right part disappears.

Since I use this prefix convention a lot, I fixed the code to show the whole branch name.
The _json_ output benefits from the fix too.

Thanks for building and maintaining this!
