### PR TITLE
Bugfix: Fix return of wrong commit hash

### DIFF
--- a/test_all.py
+++ b/test_all.py
@@ -34,7 +34,10 @@ class TestStringMethods(unittest.TestCase):
         cross_valdiating_commit_w_secret_comment = 'OH no a secret'
 
         json_result = ''
-        tmp_stdout = io.StringIO()
+        if sys.version_info >= (3,):
+            tmp_stdout = io.StringIO()
+        else:
+            tmp_stdout = io.BytesIO()
         bak_stdout = sys.stdout
 
         # Redirect STDOUT, run scan and re-establish STDOUT

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -183,7 +183,7 @@ def find_entropy(printableDiff, commit_time, branch_name, prev_commit, blob, com
         entropicDiff['diff'] = blob.diff.decode('utf-8', errors='replace')
         entropicDiff['stringsFound'] = stringsFound
         entropicDiff['printDiff'] = printableDiff
-        entropicDiff['commitHash'] = commitHash
+        entropicDiff['commitHash'] = prev_commit.hexsha
         entropicDiff['reason'] = "High Entropy"
     return entropicDiff
 
@@ -207,7 +207,7 @@ def regex_check(printableDiff, commit_time, branch_name, prev_commit, blob, comm
             foundRegex['stringsFound'] = found_strings
             foundRegex['printDiff'] = found_diff
             foundRegex['reason'] = key
-            foundRegex['commitHash'] = commitHash
+            foundRegex['commitHash'] = prev_commit.hexsha
             regex_matches.append(foundRegex)
     return regex_matches
 


### PR DESCRIPTION
Returned commit hash pointed the parent commit of the effectively wanted one. 

I.e. if a commit introduced a secret, truffleHog returned that commit's parent's hash value. The comment was from the correct commit, on the other hand. 

Also added a test working as a regression test.