### PR TITLE
Fixed handling of file-typed repositories

### DIFF
--- a/test_all.py
+++ b/test_all.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import re
 from truffleHog import truffleHog
 
 
@@ -12,7 +13,7 @@ class TestStringMethods(unittest.TestCase):
         self.assertGreater(truffleHog.shannon_entropy(random_stringHex, truffleHog.HEX_CHARS), 3)
 
     def test_cloning(self):
-        project_path = truffleHog.clone_git_repo("https://github.com/dxa4481/truffleHog.git")
+        project_path, _ = truffleHog.clone_git_repo("https://github.com/dxa4481/truffleHog.git")
         license_file = os.path.join(project_path, "LICENSE")
         self.assertTrue(os.path.isfile(license_file))
 
@@ -21,6 +22,42 @@ class TestStringMethods(unittest.TestCase):
             truffleHog.find_strings("https://github.com/dxa4481/tst.git")
         except UnicodeEncodeError:
             self.fail("Unicode print error")
+
+
+class TestRepoTypes(unittest.TestCase):
+    def test_file_repo(self):
+        # First, we'll clone the remote repo
+        git_url = "https://github.com/dxa4481/truffleHog.git"
+        project_path_1, c = truffleHog.clone_git_repo(git_url)
+        self.assertTrue(re.search(r'^/tmp/', project_path_1))
+        
+        # Second, we'll use a local repo without cloning
+        project_path_2, c = truffleHog.clone_git_repo('file://' + project_path_1)
+        self.assertTrue(re.search(r'^/tmp/', project_path_2))
+        self.assertEqual(project_path_1, project_path_2)
+
+        # Third, we'll use a sloppy filepath as a project repo address
+        project_path_3, c = truffleHog.clone_git_repo(project_path_2)
+        self.assertTrue(re.search(r'^/tmp/', project_path_3))
+        self.assertEqual(project_path_2, project_path_3)        
+
+        # Fourth, we'll force another clone from a local repo
+        project_path_4, c = truffleHog.clone_git_repo('file://' + project_path_3, force=True)
+        self.assertTrue(re.search(r'^/tmp/', project_path_4))
+        self.assertNotEqual(project_path_3, project_path_4)
+
+    def test_remove_only_temp_repos(self):
+        # First, we'll clone the remote repo
+        git_url = "https://github.com/dxa4481/truffleHog.git"
+        project_path, created = truffleHog.clone_git_repo(git_url)
+        self.assertTrue(re.search(r'^/tmp/', project_path))
+        self.assertTrue(created)
+
+        # Second, we'll use a local repo without cloning to find strigs
+        truffleHog.find_strings('file://' + project_path)
+        self.assertTrue(os.path.exists(project_path))
+        
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a 'force_clone' flag, that allows for a decision on how to handle local ('file://') repositories.

Allows for scanning already existing repositories, i.e. on your local disk. 

By default, file://-typed repositories will no longer get cloned (and consequently also not deleted, once the job is done) - unless the ``force_clone`` flag is specified. 