### PR TITLE
Adding feature to pass path to an already cloned repo

### DIFF
--- a/test_all.py
+++ b/test_all.py
@@ -60,11 +60,20 @@ class TestStringMethods(unittest.TestCase):
 
     @patch('truffleHog.truffleHog.clone_git_repo')
     @patch('truffleHog.truffleHog.Repo')
-    def test_branch(self, repo_const_mock, clone_git_repo): 
+    @patch('shutil.rmtree')
+    def test_branch(self, rmtree_mock, repo_const_mock, clone_git_repo):
         repo = MagicMock()
         repo_const_mock.return_value = repo
         truffleHog.find_strings("test_repo", branch="testbranch")
         repo.remotes.origin.fetch.assert_called_once_with("testbranch")
+
+    @patch('truffleHog.truffleHog.clone_git_repo')
+    @patch('truffleHog.truffleHog.Repo')
+    @patch('shutil.rmtree')
+    def test_repo_path(self, rmtree_mock, repo_const_mock, clone_git_repo):
+        truffleHog.find_strings("test_repo", repo_path="test/path/")
+        rmtree_mock.assert_not_called()
+        clone_git_repo.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -28,6 +28,7 @@ def main():
     parser.add_argument("--since_commit", dest="since_commit", help="Only scan from a given commit hash")
     parser.add_argument("--max_depth", dest="max_depth", help="The max commit depth to go back when searching for secrets")
     parser.add_argument("--branch", dest="branch", help="Name of the branch to be scanned")
+    parser.add_argument("--repo_path", type=str, dest="repo_path", help="Path to the cloned repo. If provided, git_url will not be used")
     parser.add_argument('git_url', type=str, help='URL for secret searching')
     parser.set_defaults(regex=False)
     parser.set_defaults(rules={})
@@ -35,6 +36,7 @@ def main():
     parser.set_defaults(since_commit=None)
     parser.set_defaults(entropy=True)
     parser.set_defaults(branch=None)
+    parser.set_defaults(repo_path=None)
     args = parser.parse_args()
     rules = {}
     if args.rules:
@@ -50,9 +52,7 @@ def main():
         for regex in rules:
             regexes[regex] = rules[regex]
     do_entropy = str2bool(args.do_entropy)
-    output = find_strings(args.git_url, args.since_commit, args.max_depth, args.output_json, args.do_regex, do_entropy, surpress_output=False, branch=args.branch)
-    project_path = output["project_path"]
-    shutil.rmtree(project_path, onerror=del_rw)
+    output = find_strings(args.git_url, args.since_commit, args.max_depth, args.output_json, args.do_regex, do_entropy, surpress_output=False, branch=args.branch, repo_path=args.repo_path)
     if output["foundIssues"]:
         sys.exit(1)
     else:
@@ -242,9 +242,12 @@ def handle_results(output, output_dir, foundIssues):
         output["foundIssues"].append(result_path)
     return output
 
-def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False, do_regex=False, do_entropy=True, surpress_output=True, custom_regexes={}, branch=None):
+def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False, do_regex=False, do_entropy=True, surpress_output=True, custom_regexes={}, branch=None, repo_path=None):
     output = {"foundIssues": []}
-    project_path = clone_git_repo(git_url)
+    if repo_path:
+        project_path = repo_path
+    else:
+        project_path = clone_git_repo(git_url)
     repo = Repo(project_path)
     already_searched = set()
     output_dir = tempfile.mkdtemp()
@@ -289,6 +292,8 @@ def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False,
     output["project_path"] = project_path
     output["clone_uri"] = git_url
     output["issues_path"] = output_dir
+    if not repo_path:
+        shutil.rmtree(project_path, onerror=del_rw)
     return output
 
 def clean_up(output):


### PR DESCRIPTION
This helps because of 2 reasons: 
1. If you don't want to make multiple copies of an existing repo. 
2. You can check out a particular sha on a repo and then pass the path to trufflehog. 