### PR TITLE
Remove extraneous print from clean_up method

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -356,7 +356,6 @@ def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False,
     return output
 
 def clean_up(output):
-    print("Whhaat")
     issues_path = output.get("issues_path", None)
     if issues_path and os.path.isdir(issues_path):
         shutil.rmtree(output["issues_path"])


### PR DESCRIPTION
This extraneous print of "Whhaat" will cause issues with both the `--cleanup` and the `--json` flag set and input piped into a JSON parser.