### PR TITLE
Bug fix : closing repo before deleting temp files

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -352,6 +352,7 @@ def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False,
     output["clone_uri"] = git_url
     output["issues_path"] = output_dir
     if not repo_path:
+	repo.close()
         shutil.rmtree(project_path, onerror=del_rw)
     return output
 


### PR DESCRIPTION
This fixes the bugs reported in issues #2 and #153 by simply calling close() method on the Repo object before deleting temporary files.