### PR TITLE
Fix versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-GitPython==3.0.6
+GitPython==2.1.15
 unittest2==1.1.0
 pytest-cov==2.5.1
 codecov==2.0.15

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license='GNU',
     packages = ['truffleHog'],
     install_requires=[
-        'GitPython == 3.0.6',
+        'GitPython == 2.1.15',
         'truffleHogRegexes == 0.0.7'
     ],
     entry_points = {


### PR DESCRIPTION
GitPython 3.0.6 is not found in the requirements.

The current build is broken https://travis-ci.org/github/dxa4481/truffleHog