### PR TITLE
Add allow list for known secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ Feel free to also contribute high signal regexes upstream that you think will be
 
 trufflehog's base rule set sources from https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
 
-To explicitly allow particular secrets (e.g. self-signed keys used only for local testing) you can provide an allow list `--allow /path/to/allow` in the same format as the rules file:
+To explicitly allow particular secrets (e.g. self-signed keys used only for local testing) you can provide an allow list `--allow /path/to/allow` in the following format:
 ```
 {
-    "local self signed test key": "-----BEGIN EC PRIVATE KEY(\\n)?-----foobar123-----(\\n)?END EC PRIVATE KEY-----",
-    "git cherry pick SHAs": "Cherry picked from .*",
+    "local self signed test key": "-----BEGIN EC PRIVATE KEY-----\nfoobar123\n-----END EC PRIVATE KEY-----",
+    "git cherry pick SHAs": "regex:Cherry picked from .*",
 }
 ```
+
+Note that values beginning with `regex:` will be used as regular expressions. Values without this will be literal, with some automatic conversions (e.g. flexible newlines).
 
 ## How it works
 This module will go through the entire commit history of each branch, and check each diff from each commit, and check for secrets. This is both by regex and by entropy. For entropy checks, truffleHog will evaluate the shannon entropy for both the base64 char set and hexidecimal char set for every blob of text greater than 20 characters comprised of those character sets in each diff. If at any point a high entropy string >20 characters is detected, it will print to the screen.

--- a/README.md
+++ b/README.md
@@ -71,13 +71,21 @@ Feel free to also contribute high signal regexes upstream that you think will be
 
 trufflehog's base rule set sources from https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
 
+To explicitly allow particular secrets (e.g. self-signed keys used only for local testing) you can provide an allow list `--allow /path/to/allow` in the same format as the rules file:
+```
+{
+    "local self signed test key": "-----BEGIN EC PRIVATE KEY(\\n)?-----foobar123-----(\\n)?END EC PRIVATE KEY-----",
+    "git cherry pick SHAs": "Cherry picked from .*",
+}
+```
+
 ## How it works
 This module will go through the entire commit history of each branch, and check each diff from each commit, and check for secrets. This is both by regex and by entropy. For entropy checks, truffleHog will evaluate the shannon entropy for both the base64 char set and hexidecimal char set for every blob of text greater than 20 characters comprised of those character sets in each diff. If at any point a high entropy string >20 characters is detected, it will print to the screen.
 
 ## Help
 
 ```
-usage: trufflehog [-h] [--json] [--regex] [--rules RULES]
+usage: trufflehog [-h] [--json] [--regex] [--rules RULES] [--allow ALLOW]
                   [--entropy DO_ENTROPY] [--since_commit SINCE_COMMIT]
                   [--max_depth MAX_DEPTH]
                   git_url
@@ -92,6 +100,7 @@ optional arguments:
   --json                Output in JSON
   --regex               Enable high signal regex checks
   --rules RULES         Ignore default regexes and source from json list file
+  --allow ALLOW         Explicitly allow regexes from json list file
   --entropy DO_ENTROPY  Enable entropy checks
   --since_commit SINCE_COMMIT
                         Only scan from a given commit hash

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -103,7 +103,7 @@ def read_pattern(r):
     if r.startswith("regex:"):
         return re.compile(r[6:])
     converted = re.escape(r)
-    converted = re.sub(r"(\r?\n|(\\+r)?\\+n)+", r"([ \t]*(\r?\n|(\\\\+r)?\\\\+n)[ \t]*)*", converted)
+    converted = re.sub(r"((\\*\r)?\\*\n|(\\+r)?\\+n)+", r"( |\\t|(\\r|\\n|\\\\+[rn])[-+]?)*", converted)
     return re.compile(converted)
 
 def str2bool(v):

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -72,7 +72,7 @@ def main():
             with open(args.allow, "r") as allowFile:
                 allow = json.loads(allowFile.read())
                 for rule in allow:
-                    allow[rule] = re.compile(allow[rule])
+                    allow[rule] = re.compile(make_flexible(allow[rule]))
         except (IOError, ValueError) as e:
             raise("Error reading allow file")
     do_entropy = str2bool(args.do_entropy)
@@ -98,6 +98,9 @@ def main():
         sys.exit(1)
     else:
         sys.exit(0)
+
+def make_flexible(r):
+    return re.sub(r"(\r?\n|(\\+r)?\\+n)+", "([ \t]*(\r?\n|(\\+r)?\\+n)[ \t]*)*", r)
 
 def str2bool(v):
     if v == None:

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -25,6 +25,7 @@ def main():
     parser.add_argument('--json', dest="output_json", action="store_true", help="Output in JSON")
     parser.add_argument("--regex", dest="do_regex", action="store_true", help="Enable high signal regex checks")
     parser.add_argument("--rules", dest="rules", help="Ignore default regexes and source from json list file")
+    parser.add_argument("--allow", dest="allow", help="Explicitly allow regexes from json list file")
     parser.add_argument("--entropy", dest="do_entropy", help="Enable entropy checks")
     parser.add_argument("--since_commit", dest="since_commit", help="Only scan from a given commit hash")
     parser.add_argument("--max_depth", dest="max_depth", help="The max commit depth to go back when searching for secrets")
@@ -44,6 +45,7 @@ def main():
     parser.add_argument('git_url', type=str, help='URL for secret searching')
     parser.set_defaults(regex=False)
     parser.set_defaults(rules={})
+    parser.set_defaults(allow={})
     parser.set_defaults(max_depth=1000000)
     parser.set_defaults(since_commit=None)
     parser.set_defaults(entropy=True)
@@ -64,6 +66,15 @@ def main():
             del regexes[regex]
         for regex in rules:
             regexes[regex] = rules[regex]
+    allow = {}
+    if args.allow:
+        try:
+            with open(args.allow, "r") as allowFile:
+                allow = json.loads(allowFile.read())
+                for rule in allow:
+                    allow[rule] = re.compile(allow[rule])
+        except (IOError, ValueError) as e:
+            raise("Error reading allow file")
     do_entropy = str2bool(args.do_entropy)
 
     # read & compile path inclusion/exclusion patterns
@@ -79,7 +90,7 @@ def main():
                 path_exclusions.append(re.compile(pattern))
 
     output = find_strings(args.git_url, args.since_commit, args.max_depth, args.output_json, args.do_regex, do_entropy,
-            surpress_output=False, branch=args.branch, repo_path=args.repo_path, path_inclusions=path_inclusions, path_exclusions=path_exclusions)
+            surpress_output=False, branch=args.branch, repo_path=args.repo_path, path_inclusions=path_inclusions, path_exclusions=path_exclusions, allow=allow)
     project_path = output["project_path"]
     if args.cleanup:
         clean_up(output)
@@ -243,7 +254,7 @@ def regex_check(printableDiff, commit_time, branch_name, prev_commit, blob, comm
             regex_matches.append(foundRegex)
     return regex_matches
 
-def diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_regexes, do_entropy, do_regex, printJson, surpress_output, path_inclusions, path_exclusions):
+def diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_regexes, do_entropy, do_regex, printJson, surpress_output, path_inclusions, path_exclusions, allow):
     issues = []
     for blob in diff:
         printableDiff = blob.diff.decode('utf-8', errors='replace')
@@ -251,6 +262,8 @@ def diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_
             continue
         if not path_included(blob, path_inclusions, path_exclusions):
             continue
+        for key in allow:
+            printableDiff = allow[key].sub('', printableDiff)
         commit_time =  datetime.datetime.fromtimestamp(prev_commit.committed_date).strftime('%Y-%m-%d %H:%M:%S')
         foundIssues = []
         if do_entropy:
@@ -301,7 +314,7 @@ def path_included(blob, include_patterns=None, exclude_patterns=None):
 
 
 def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False, do_regex=False, do_entropy=True, surpress_output=True,
-                custom_regexes={}, branch=None, repo_path=None, path_inclusions=None, path_exclusions=None):
+                custom_regexes={}, branch=None, repo_path=None, path_inclusions=None, path_exclusions=None, allow={}):
     output = {"foundIssues": []}
     if repo_path:
         project_path = repo_path
@@ -341,12 +354,12 @@ def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False,
                 diff = prev_commit.diff(curr_commit, create_patch=True)
             # avoid searching the same diffs
             already_searched.add(diff_hash)
-            foundIssues = diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_regexes, do_entropy, do_regex, printJson, surpress_output, path_inclusions, path_exclusions)
+            foundIssues = diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_regexes, do_entropy, do_regex, printJson, surpress_output, path_inclusions, path_exclusions, allow)
             output = handle_results(output, output_dir, foundIssues)
             prev_commit = curr_commit
         # Handling the first commit
         diff = curr_commit.diff(NULL_TREE, create_patch=True)
-        foundIssues = diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_regexes, do_entropy, do_regex, printJson, surpress_output, path_inclusions, path_exclusions)
+        foundIssues = diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_regexes, do_entropy, do_regex, printJson, surpress_output, path_inclusions, path_exclusions, allow)
         output = handle_results(output, output_dir, foundIssues)
     output["project_path"] = project_path
     output["clone_uri"] = git_url

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -103,7 +103,7 @@ def read_pattern(r):
     if r.startswith("regex:"):
         return re.compile(r[6:])
     converted = re.escape(r)
-    converted = re.sub(r"(\r?\n|(\\+r)?\\+n)+", "([ \t]*(\r?\n|(\\\\+r)?\\\\+n)[ \t]*)*", converted)
+    converted = re.sub(r"(\r?\n|(\\+r)?\\+n)+", r"([ \t]*(\r?\n|(\\\\+r)?\\\\+n)[ \t]*)*", converted)
     return re.compile(converted)
 
 def str2bool(v):

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -72,7 +72,7 @@ def main():
             with open(args.allow, "r") as allowFile:
                 allow = json.loads(allowFile.read())
                 for rule in allow:
-                    allow[rule] = re.compile(make_flexible(allow[rule]))
+                    allow[rule] = read_pattern(allow[rule])
         except (IOError, ValueError) as e:
             raise("Error reading allow file")
     do_entropy = str2bool(args.do_entropy)
@@ -99,8 +99,12 @@ def main():
     else:
         sys.exit(0)
 
-def make_flexible(r):
-    return re.sub(r"(\r?\n|(\\+r)?\\+n)+", "([ \t]*(\r?\n|(\\+r)?\\+n)[ \t]*)*", r)
+def read_pattern(r):
+    if r.startswith("regex:"):
+        return re.compile(r[6:])
+    converted = re.escape(r)
+    converted = re.sub(r"(\r?\n|(\\+r)?\\+n)+", "([ \t]*(\r?\n|(\\+r)?\\+n)[ \t]*)*", converted)
+    return re.compile(converted)
 
 def str2bool(v):
     if v == None:

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -103,7 +103,7 @@ def read_pattern(r):
     if r.startswith("regex:"):
         return re.compile(r[6:])
     converted = re.escape(r)
-    converted = re.sub(r"(\r?\n|(\\+r)?\\+n)+", "([ \t]*(\r?\n|(\\+r)?\\+n)[ \t]*)*", converted)
+    converted = re.sub(r"(\r?\n|(\\+r)?\\+n)+", "([ \t]*(\r?\n|(\\\\+r)?\\\\+n)[ \t]*)*", converted)
     return re.compile(converted)
 
 def str2bool(v):


### PR DESCRIPTION
This PR adds the ability to provide a set of known secrets which are OK if found in the repository. This is useful in conjunction with the entropy checks, as it can filter out complex-looking but harmless patterns. Because the rest of the diff is still checked, this is much safer than filtering out whole files.

```
trufflehog --allow=myAllowList.json
```

For example:

```json
{
  "local self-signed test key": "---- BEGIN PRIVATE KEY ----\nABC/123+abc=\n---- END PRIVATE KEY ----",
  "false positive": "aLongTestNameWhichLooksLikeItHasHighEntropyButReallyDoesNot"
}
```

Note that `+` does not need to be escaped here (the values are literal), and the `\n`s will be re-written as flexible regular expressions allowing various styles of separation or none at all.

Regex is also supported with a prefix:

```json
{
  "integrity-check": "regex:sha(1|256|512)-[0-9a-zA-Z/+=]+",
  "git cherry pick message": "regex:Cherry picked from .*"
}
```

Will ignore various SHAs which would otherwise appear to be high entropy.

---

Happy to add testing around this but it doesn't look like there's much existing testing (that I could find). So far it's been tested in the real-world on a repository.